### PR TITLE
add support for node 14, drop support for 9

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [9.x, 10.x, 11.x, 12.x, 13.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
* Node 14 released 2020-04-21
* Node 9 dropped support like 2 years ago, but Jest dropped support of it when it dropped support of Node 8, and blocks #25