### PR TITLE
Allow passing constants in and treat as random seed

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -18,6 +18,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run build --if-present
-      - run: npm test
+      - run: npm test:coverage
         env:
           CI: true

--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -18,6 +18,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run build --if-present
-      - run: npm test:coverage
+      - run: npm test
         env:
           CI: true

--- a/README.md
+++ b/README.md
@@ -27,15 +27,12 @@ const sortedDeck = suits.map((suit) => faces.map((face) => face + suit))
 const shuffledDeck = shuffle(sortedDeck)
 ```
 
-By giving it a pseudoRNG, you can also safely use it in your redux reducers. You'll need a random float for every element in your array; if you use a twister to generate infinite randomness, you'll have to stick its state somewhere. `Math.random` doesn't allow you to specify a deterministic seed.
+The default export allows you to specify your own random seed, which makes it deterministic and safe for use in redux reducers. `Math.random` doesn't allow you to specify a deterministic seed, but this uses its own built-in Mersenne-Twister RNG. If you had your own source of entropy, you can give that as a function as well.
 
 ```js
 import fastShuffle from 'fast-shuffle'
-import MersenneTwister from 'mersenne-twister'
 
-const seededRandomizer = new MersenneTwister(12345)
-const noise = new Array(9000).fill().map(() => seededRandomizer.random())
-const shuffle = fastShuffle(() => noise.pop())
+const shuffle = fastShuffle(12345)
 
 const state = {
   deck: sortedDeck
@@ -57,12 +54,9 @@ Since the parameters are curried, it can be used in [pipelines](https://github.c
 import fastShuffle from 'fast-shuffle'
 
 const randomLetter =
-  // arrayOfLetters :: () -> [a]
-  ['a', 'b', 'c', 'd']
-  // shuffle :: [a] -> [a]
-  |> fastShuffle(Math.random),
-  // head :: [a] -> a
-  |> (array) => array[0]
+  ['a', 'b', 'c', 'd']             // :: () -> [a]
+  |> fastShuffle(Math.random),     // :: [a] -> [a]
+  |> (array) => array[0]           // :: [a] -> a
 ```
 
 ## Why not use existing libraries?
@@ -71,9 +65,9 @@ const randomLetter =
 
 2. The parameters are curried in [the correct order](https://www.youtube.com/watch?v=m3svKOdZijA), so you can use it within `|>` or Ramda pipes.
 
-3. It's stupid-fast, compared to other libraries.
+3. It's stupid-fast and scales to large arrays without breaking a sweat.
 
-4. Compatible with any random number generator.
+4. You can BYO-RNG.
 
 ## Optimizations
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/philihp/fast-shuffle/badge.svg?branch=master)](https://coveralls.io/github/philihp/fast-shuffle?branch=master)
 ![License](https://img.shields.io/npm/l/fast-shuffle)
 
-A fast, side-effect free, dependency-free array shuffle that's safe for functional
+A fast and side-effect free array shuffle that's safe for functional
 programming, and use within Redux reducers. The parameters are properly curried as
 well, so you can pass it in with Ramda pipes.
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   },
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "mersenne-twister": "1.1.0"
+  },
   "devDependencies": {
     "@babel/cli": "7.10.3",
     "@babel/core": "7.10.3",
@@ -42,7 +44,6 @@
     "husky": "4.2.5",
     "jest-nyancat-reporter": "2.0.0",
     "lint-staged": "10.2.11",
-    "mersenne-twister": "1.1.0",
     "prettier": "2.0.5",
     "ramda": "0.27.0"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "ramda": "0.27.0"
   },
   "jest": {
-    "rootDir": "src",
+    "modulePathIgnorePatterns": [
+      "dist/"
+    ],
     "reporters": [
       [
         "jest-nyancat-reporter",

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,52 +1,50 @@
-import MersenneTwister from 'mersenne-twister'
 import { pipe } from 'ramda'
 import fastShuffle, { shuffle } from '..'
-
-const twister = new MersenneTwister(12345)
-const noise = (length) => new Array(length).fill().map(() => twister.random())
 
 describe('default', () => {
   it('shuffles the array', () => {
     expect.assertions(2)
+    const pseudoShuffle = fastShuffle(12345)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
-
-    const noiseBank = noise(8)
-    const d2 = fastShuffle(() => noiseBank.pop())(d1)
+    const d2 = pseudoShuffle(d1)
     expect(d2).toStrictEqual(expect.arrayContaining(d1))
     expect(d2).toHaveLength(d1.length)
   })
 
   it('does not mutate the source', () => {
     expect.assertions(1)
+    const pseudoShuffle = fastShuffle(12345)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
-    const noiseBank = noise(8)
-    fastShuffle(() => noiseBank.pop())(d1)
+    pseudoShuffle(d1)
     expect(d1).toMatchObject(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'])
   })
 
   it('does a shallow clone', () => {
-    expect.assertions(4)
+    expect.assertions(2)
+    const pseudoShuffle = fastShuffle(12345)
     const d1 = [
       { name: 'Alice', money: 10 },
       { name: 'Betty', money: 20 },
       { name: 'Cindy', money: 15 },
     ]
-    const noiseBank = noise(4)
-    const pseudoShuffle = fastShuffle(() => noiseBank.pop())
     const d2 = pseudoShuffle(d1)
-    // given the numbers above, should be alice, cindy, betty
-    expect(d2[0].name).toBe('Alice')
-    expect(d2[0].money).toBe(10)
+    expect(d2).toStrictEqual([
+      { name: 'Cindy', money: 15 },
+      { name: 'Betty', money: 20 },
+      { name: 'Alice', money: 10 },
+    ])
     d2[0].money = 40
-    expect(d1[0].name).toBe('Alice')
-    expect(d1[0].money).toBe(40)
+    expect(d1).toStrictEqual([
+      { name: 'Alice', money: 10 },
+      { name: 'Betty', money: 20 },
+      { name: 'Cindy', money: 40 },
+    ])
   })
 
   it('can be sorted back into the source array', () => {
     expect.assertions(1)
+    const pseudoShuffle = fastShuffle(12345)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'].sort()
-    const noiseBank = noise(8)
-    const pseudoShuffle = fastShuffle(() => noiseBank.pop())
     const d2 = pseudoShuffle(d1)
     const d3 = d2.sort()
     expect(d3).toMatchObject(d1)
@@ -59,6 +57,35 @@ describe('default', () => {
     fastShuffle(rng)(d)
     expect(rng).toHaveBeenCalledTimes(d.length)
   })
+
+  it('can be piped', () => {
+    expect.assertions(1)
+    const pseudoShuffle = fastShuffle(12345)
+    const letters = () => ['a', 'b', 'c', 'd']
+    const head = (array) => array?.[0]
+    const drawCard = pipe(letters, pseudoShuffle, head)
+    expect(drawCard()).toBe('d')
+  })
+
+  it('accepts a custom random function', () => {
+    expect.assertions(1)
+    const noise = [
+      0.8901547130662948,
+      0.3163755603600294,
+      0.1307072939816823,
+      0.1839188123121576,
+      0.0397594964593742,
+      0.2045602793853012,
+      0.8264361317269504,
+      0.5677250262815505,
+      0.5320779164321721,
+      0.5955447026062757,
+    ]
+    const pseudoShuffle = fastShuffle(() => noise.pop())
+    const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+    const d2 = pseudoShuffle(d1)
+    expect(d1).not.toStrictEqual(d2)
+  })
 })
 
 describe('shuffle', () => {
@@ -67,15 +94,5 @@ describe('shuffle', () => {
     const d1 = new Array(500000).fill().map((_, i) => i)
     const d2 = shuffle(d1)
     expect(d1.sort()).toMatchObject(d2.sort())
-  })
-
-  it('can be piped', () => {
-    expect.assertions(1)
-    const letters = () => ['a', 'b', 'c', 'd']
-    const noiseBank = noise(8)
-    const randomShuffle = fastShuffle(() => noiseBank.pop())
-    const head = (array) => array?.[0]
-    const drawCard = pipe(letters, randomShuffle, head)
-    expect(drawCard()).toBe('c')
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
 import MersenneTwister from 'mersenne-twister'
 
-const ruffle = (randomSeed) => {
-  let Randomizer
-  let random
-  if (typeof randomSeed === 'function') {
-    random = () => randomSeed()
-  } else {
-    Randomizer = new MersenneTwister(randomSeed)
-    random = () => Randomizer.random()
+const randomFunction = (random) => {
+  if (typeof random === 'function') {
+    return random
   }
+  const Randomizer = new MersenneTwister(random)
+  return () => Randomizer.random()
+}
+
+const ruffle = (randomSeed) => {
+  const random = randomFunction(randomSeed)
   return (deck) => {
     const clone = deck.slice(0)
     let sourceIndex = deck.length

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,28 @@
-const ruffle = (random) => (deck) => {
-  const clone = deck.slice(0)
-  let sourceIndex = deck.length
-  let destinationIndex = 0
-  const shuffled = new Array(sourceIndex)
+import MersenneTwister from 'mersenne-twister'
 
-  while (sourceIndex) {
-    const randomIndex = (sourceIndex * random()) | 0
-    shuffled[destinationIndex++] = clone[randomIndex]
-    clone[randomIndex] = clone[--sourceIndex]
+const ruffle = (randomSeed) => {
+  let Randomizer
+  let random
+  if (typeof randomSeed === 'function') {
+    random = () => randomSeed()
+  } else {
+    Randomizer = new MersenneTwister(randomSeed)
+    random = () => Randomizer.random()
   }
+  return (deck) => {
+    const clone = deck.slice(0)
+    let sourceIndex = deck.length
+    let destinationIndex = 0
+    const shuffled = new Array(sourceIndex)
 
-  return shuffled
+    while (sourceIndex) {
+      const randomIndex = (sourceIndex * random()) | 0
+      shuffled[destinationIndex++] = clone[randomIndex]
+      clone[randomIndex] = clone[--sourceIndex]
+    }
+
+    return shuffled
+  }
 }
 
 export const shuffle = ruffle(Math.random)


### PR DESCRIPTION
To make the library easier to use, include `mersenne-twister` as a dependency, and if the randomSeed isn't a function, use it as the seed. So rather than doing

```js
import MersenneTwister from 'mersenne-twister'
const twister = new MersenneTwister(12345)
const shuffle = fastShuffle(twister.random)
```

this becomes

```js
const shuffle = fastShuffle(12345)
```

Old way still works in case someone has their own RNG.