### PR TITLE
Simpler interface for Redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/philihp/fast-shuffle/badge.svg?branch=master)](https://coveralls.io/github/philihp/fast-shuffle?branch=master)
 ![License](https://img.shields.io/npm/l/fast-shuffle)
 
-A fast and side-effect free array shuffle that's safe for functional
-programming, and use within Redux reducers. The parameters are properly curried as
-well, so you can pass it in with Ramda pipes.
+A fast and side-effect free array shuffle that's safe for functional programming, and use within Redux reducers.
 
 ## Usage
 
@@ -27,35 +25,31 @@ const shuffledDeck = shuffle(sortedDeck)
 // [ '3♥', '3♦', 'K♥', '6♦', 'J♣', '5♠', 'A♠', ...
 ```
 
-The shuffle export uses `Math.random` for entropy. You can use the default
-export and specify your own seed, which makes it deterministic pure function.
+The named shuffle export, above, uses `Math.random` for entropy. If you import it without the brackets, you'll get a functionally pure shuffler, which you can give it an integer
 
 ```js
-import fastShuffle from 'fast-shuffle'
+import shuffle from 'fast-shuffle'
 
 const letters = ['a', 'b', 'c', 'd', 'e']
-let pseudoShuffle = fastShuffle(12345)
+let pseudoShuffle = shuffle(12345)
 
 pseudoShuffle(letters) // [ 'e', 'd', 'a', 'c', 'b' ]
 pseudoShuffle(letters) // [ 'a', 'e', 'c', 'b', 'd' ]
 
-pseudoShuffle = fastShuffle(12345)
+pseudoShuffle = shuffle(12345)
 pseudoShuffle(letters) // [ 'e', 'd', 'a', 'c', 'b' ]
 pseudoShuffle(letters) // [ 'a', 'e', 'c', 'b', 'd' ]
 ```
 
-For [performance reasons](https://redux.js.org/faq/performance), it doesn't mutate the original array. Instead, it returns a shallow copy so downstream your React components will know not
-to rerender themselves. Since it's a pure function and does not mutate the input, you can use
-it in your Redux reducers.
+It doesn't mutate the original array, instead it gives you back a shallow copy, which is important for Redux/React and [performance reasons](https://redux.js.org/faq/performance).
 
 ```js
 import { SHUFFLE_DECK } from './actions'
-import fastShuffle from 'fast-shuffle'
-import MersenneTwister from 'mersenne-twister'
+import shuffle from 'fast-shuffle'
 
 const initialState = {
   ...
-  transitiveSeed: new MersenneTwister(Math.random() * Date.now()).random_int(),
+  randomizer: Date.now(),
   deck: ['♣', '♦', '♥', '♠']
 }
 
@@ -63,10 +57,11 @@ const dealerApp = (state = initialState, action) => {
   switch (action.type) {
     ...
     case SHUFFLE_DECK:
+      const [ deck, randomizer ] = shuffle([state.deck, state.randomizer])
       return {
         ...state,
-        transitiveSeed: new MersenneTwister(state.transitiveSeed).random_int(),
-        deck: fastShuffle(state.transitiveSeed, state.deck)
+        randomizer,
+        deck
       }
     ...
     default:
@@ -78,11 +73,11 @@ const dealerApp = (state = initialState, action) => {
 The parameters are also curried, so it can be used in [pipelines](https://github.com/tc39/proposal-pipeline-operator).
 
 ```js
-import fastShuffle from 'fast-shuffle'
+import shuffle from 'fast-shuffle'
 
 const randomCapitalLetter =
   ['a', 'b', 'c', 'd', 'e', 'f']   // :: () -> [a]
-  |> fastShuffle(Math.random),     // :: [a] -> [a]
+  |> shuffle(Math.random),     // :: [a] -> [a]
   |> _ => _[0]                     // :: [a] -> a
   |> _ => _.toUpperCase()          // :: a -> a
 ```

--- a/README.md
+++ b/README.md
@@ -96,11 +96,3 @@ const randomCapitalLetter =
 3. It's stupid-fast and scales to large arrays without breaking a sweat.
 
 4. You can BYO-RNG.
-
-## Optimizations
-
-- Don't use splice. Removing elements with splice preserves order, and slows
-  the shuffle run to quadratic time.
-- Avoid repeated pop() and push(). The ultimate size of the output array
-  will not change.
-- Avoid Math.floor. Remove fractions with a binary or with zero.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "mersenne-twister": "1.1.0"
+    "fn-mt": "1.2.1"
   },
   "devDependencies": {
     "@babel/cli": "7.10.3",

--- a/package.json
+++ b/package.json
@@ -50,14 +50,6 @@
   "jest": {
     "modulePathIgnorePatterns": [
       "dist/"
-    ],
-    "reporters": [
-      [
-        "jest-nyancat-reporter",
-        {
-          "suppressErrorReporter": false
-        }
-      ]
     ]
   },
   "lint-staged": {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -30,8 +30,8 @@ describe('default', () => {
     const d2 = pseudoShuffle(d1)
     expect(d2).toStrictEqual([
       { name: 'Cindy', money: 15 },
-      { name: 'Betty', money: 20 },
       { name: 'Alice', money: 10 },
+      { name: 'Betty', money: 20 },
     ])
     d2[0].money = 40
     expect(d1).toStrictEqual([
@@ -110,7 +110,7 @@ describe('default', () => {
     expect.assertions(1)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const d2 = fastShuffle(12345, d1)
-    expect(d2).toStrictEqual(['H', 'G', 'B', 'A', 'E', 'D', 'C', 'F'])
+    expect(d2).toStrictEqual(['G', 'A', 'F', 'D', 'B', 'E', 'H', 'C'])
   })
 })
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -153,4 +153,13 @@ describe('fastShuffle for reducers', () => {
     const [d1] = fastShuffle([s1, undefined])
     expect(s1.every((r) => d1.includes(r))).toBe(true)
   })
+
+  it('nondeterministically seeds, if no seed provided', () => {
+    expect.assertions(2)
+    const s1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+    const [d1, r1] = fastShuffle([s1, undefined])
+    const [d2, r2] = fastShuffle([s1, undefined])
+    expect(d1.every((r) => d2.includes(r))).toBe(true)
+    expect(r1).not.toStrictEqual(r2)
+  })
 })

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -20,7 +20,7 @@ describe('default', () => {
   })
 
   it('does a shallow clone', () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const pseudoShuffle = fastShuffle(12345)
     const d1 = [
       { name: 'Alice', money: 10 },
@@ -28,17 +28,10 @@ describe('default', () => {
       { name: 'Cindy', money: 15 },
     ]
     const d2 = pseudoShuffle(d1)
-    expect(d2).toStrictEqual([
-      { name: 'Cindy', money: 15 },
-      { name: 'Alice', money: 10 },
-      { name: 'Betty', money: 20 },
-    ])
-    d2[0].money = 40
-    expect(d1).toStrictEqual([
-      { name: 'Alice', money: 10 },
-      { name: 'Betty', money: 20 },
-      { name: 'Cindy', money: 40 },
-    ])
+    // toBe tests identity, not deep equality
+    expect(d2).toContain(d1[0])
+    expect(d2).toContain(d1[1])
+    expect(d2).toContain(d1[2])
   })
 
   it('can be sorted back into the source array', () => {
@@ -64,7 +57,7 @@ describe('default', () => {
     const letters = () => ['a', 'b', 'c', 'd']
     const head = (array) => array?.[0]
     const drawCard = pipe(letters, pseudoShuffle, head)
-    expect(drawCard()).toBe('d')
+    expect(drawCard()).toBe('b')
   })
 
   it('accepts a custom random function', () => {
@@ -132,7 +125,7 @@ describe('default', () => {
     expect.assertions(1)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const d2 = fastShuffle(12345, d1)
-    expect(d2).toStrictEqual(['G', 'A', 'F', 'D', 'B', 'E', 'H', 'C'])
+    expect(d2).toStrictEqual(['B', 'H', 'F', 'C', 'G', 'A', 'D', 'E'])
   })
 })
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -87,8 +87,8 @@ describe('default', () => {
     expect(d1).not.toStrictEqual(d2)
   })
 
-  it('also, rather than curried, accepts a function and the source array', () => {
-    expect.assertions(1)
+  it('accepts a custom random function that gives floats (0..1)', () => {
+    expect.assertions(2)
     const noise = [
       0.8901547130662948,
       0.3163755603600294,
@@ -101,9 +101,31 @@ describe('default', () => {
       0.5320779164321721,
       0.5955447026062757,
     ]
+    const pseudoShuffle = fastShuffle(() => noise.pop())
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
-    const d2 = fastShuffle(() => noise.pop(), d1)
-    expect(d2).toStrictEqual(['E', 'D', 'G', 'H', 'A', 'F', 'C', 'B'])
+    const d2 = pseudoShuffle(d1)
+    expect(d1).not.toStrictEqual(d2)
+    expect(d1.sort()).toStrictEqual(d2.sort())
+  })
+
+  it('accepts random function that gives ints', () => {
+    expect.assertions(2)
+    const noise = [
+      3319549465,
+      2740305749,
+      3900900665,
+      3358524577,
+      2094225545,
+      1681473165,
+      1218673763,
+      3934276843,
+      1762424506,
+    ]
+    const pseudoShuffle = fastShuffle(() => noise.pop())
+    const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+    const d2 = pseudoShuffle(d1)
+    expect(d1).not.toStrictEqual(d2)
+    expect(d1.sort()).toStrictEqual(d2.sort())
   })
 
   it('also, rather than curried, accepts a seed and the source array', () => {
@@ -117,7 +139,7 @@ describe('default', () => {
 describe('shuffle', () => {
   it('works with massive noise', () => {
     expect.assertions(1)
-    const d1 = new Array(500000).fill().map((_, i) => i)
+    const d1 = new Array(500).fill().map((_, i) => i)
     const d2 = shuffle(d1)
     expect(d1.sort()).toMatchObject(d2.sort())
   })

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 import { newRandGen, randRange } from 'fn-mt'
 
-const randomFunction = (random) => {
-  if (typeof random === 'function') {
-    return (maxIndex) => {
-      const nextNumber = random()
-      if (Number.isInteger(nextNumber)) {
-        return ((nextNumber / 2 ** 32) * maxIndex) | 0
-      }
-      return (nextNumber * maxIndex) | 0
-    }
+const randomFunction = (random) => (maxIndex) => {
+  const nextNumber = random()
+  if (Number.isInteger(nextNumber)) {
+    return ((nextNumber / 2 ** 32) * maxIndex) | 0
   }
+  return (nextNumber * maxIndex) | 0
+}
+
+const randomGenerator = (random) => {
+  if (typeof random === 'function') return randomFunction(random)
   let randState = newRandGen(random)
   return (maxIndex) => {
     const [nextInt, nextState] = randRange(0, maxIndex, randState)
@@ -19,7 +19,7 @@ const randomFunction = (random) => {
 }
 
 const ruffle = (randomSeed, deck) => {
-  const random = randomFunction(randomSeed)
+  const random = randomGenerator(randomSeed)
   const shuffler = (sourceArray) => {
     const clone = sourceArray.slice(0)
     let sourceIndex = sourceArray.length

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { newRandGen, randNext } from 'fn-mt'
+import { newRandGen, randRange } from 'fn-mt'
 
 const randomFunction = (random) => {
   if (typeof random === 'function') {
@@ -12,9 +12,9 @@ const randomFunction = (random) => {
   }
   let randState = newRandGen(random)
   return (maxIndex) => {
-    const [nextInt, nextState] = randNext(randState)
+    const [nextInt, nextState] = randRange(0, maxIndex, randState)
     randState = nextState
-    return ((nextInt / 2 ** 32) * maxIndex) | 0
+    return nextInt
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,20 @@
-import { randNext, newRandGen } from 'fn-mt'
+import { newRandGen, randNext } from 'fn-mt'
 
 const randomFunction = (random) => {
   if (typeof random === 'function') {
-    return random
+    return (maxIndex) => {
+      const nextNumber = random()
+      if (Number.isInteger(nextNumber)) {
+        return ((nextNumber / 2 ** 32) * maxIndex) | 0
+      }
+      return (nextNumber * maxIndex) | 0
+    }
   }
   let randState = newRandGen(random)
-  return () => {
+  return (maxIndex) => {
     const [nextInt, nextState] = randNext(randState)
     randState = nextState
-    return nextInt / 2 ** 32
+    return ((nextInt / 2 ** 32) * maxIndex) | 0
   }
 }
 
@@ -21,7 +27,7 @@ const ruffle = (randomSeed, deck) => {
     const shuffled = new Array(sourceIndex)
 
     while (sourceIndex) {
-      const randomIndex = (sourceIndex * random()) | 0
+      const randomIndex = random(sourceIndex)
       shuffled[destinationIndex++] = clone[randomIndex]
       clone[randomIndex] = clone[--sourceIndex]
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,31 @@
 import { newRandGen, randRange } from 'fn-mt'
 
-const randomFunction = (random) => (maxIndex) => {
-  const nextNumber = random()
-  if (Number.isInteger(nextNumber)) {
-    return ((nextNumber / 2 ** 32) * maxIndex) | 0
+/**
+ * This is the basic algorithm. Random should be a function that when given
+ * an integer, returns an integer 0..n; basically "give me a random index for
+ * my array. I have a hunch most of the time we will just get a seed, and should
+ * generate our own random function. Unfortunately Javascript does not let us
+ * seed the Math.random randomizer, so this uses fn-mt.
+ */
+const fisherYatesShuffle = (random) => (sourceArray) => {
+  const clone = sourceArray.slice(0)
+  let sourceIndex = sourceArray.length
+  let destinationIndex = 0
+  const shuffled = new Array(sourceIndex)
+
+  while (sourceIndex) {
+    const randomIndex = random(sourceIndex)
+    shuffled[destinationIndex++] = clone[randomIndex]
+    clone[randomIndex] = clone[--sourceIndex]
   }
-  return (nextNumber * maxIndex) | 0
+
+  return shuffled
 }
 
-const randomGenerator = (random) => {
-  if (typeof random === 'function') return randomFunction(random)
+const randomExternal = (random) => (maxIndex) =>
+  ((random() / 2 ** 32) * maxIndex) | 0
+
+const randomInternal = (random) => {
   let randState = newRandGen(random)
   return (maxIndex) => {
     const [nextInt, nextState] = randRange(0, maxIndex, randState)
@@ -18,26 +34,34 @@ const randomGenerator = (random) => {
   }
 }
 
-const ruffle = (randomSeed, deck) => {
-  const random = randomGenerator(randomSeed)
-  const shuffler = (sourceArray) => {
-    const clone = sourceArray.slice(0)
-    let sourceIndex = sourceArray.length
-    let destinationIndex = 0
-    const shuffled = new Array(sourceIndex)
+const makeRandom = (random) => {
+  if (typeof random === 'function') return randomExternal(random)
+  return randomInternal(random)
+}
 
-    while (sourceIndex) {
-      const randomIndex = random(sourceIndex)
-      shuffled[destinationIndex++] = clone[randomIndex]
-      clone[randomIndex] = clone[--sourceIndex]
-    }
-
-    return shuffled
+const functionalShuffle = (deck, state) => {
+  let randState = typeof state !== 'object' ? newRandGen(state) : state
+  const random = (maxIndex) => {
+    const [nextInt, nextState] = randRange(0, maxIndex, randState)
+    randState = nextState
+    return nextInt
   }
+  return [fisherYatesShuffle(random)(deck), randState]
+}
+
+const fastShuffle = (randomSeed, deck) => {
+  // if the first param is an object, assume it's a randomizer's state from a previous run
+  if (typeof randomSeed === 'object') {
+    const [fnDeck, fnState] = randomSeed
+    return functionalShuffle(fnDeck, fnState)
+  }
+  const random = makeRandom(randomSeed)
+  const shuffler = fisherYatesShuffle(random)
+  // if no second param given, return a curried shuffler
   if (deck === undefined) return shuffler
   return shuffler(deck)
 }
 
-export const shuffle = ruffle(Math.random)
+export const shuffle = fastShuffle(Math.random)
 
-export default ruffle
+export default fastShuffle

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { newRandGen, randRange } from 'fn-mt'
 
 /**
- * This is the basic algorithm. Random should be a function that when given
+ * This is the algorithm. Random should be a function that when given
  * an integer, returns an integer 0..n; basically "give me a random index for
  * my array. I have a hunch most of the time we will just get a seed, and should
  * generate our own random function. Unfortunately Javascript does not let us
@@ -22,6 +22,8 @@ const fisherYatesShuffle = (random) => (sourceArray) => {
   return shuffled
 }
 
+const randomInt = () => (Math.random() * 2 ** 32) | 0
+
 const randomExternal = (random) => (maxIndex) =>
   ((random() / 2 ** 32) * maxIndex) | 0
 
@@ -34,10 +36,8 @@ const randomInternal = (random) => {
   }
 }
 
-const makeRandom = (random) => {
-  if (typeof random === 'function') return randomExternal(random)
-  return randomInternal(random)
-}
+const randomSwitch = (random) =>
+  (typeof random === 'function' ? randomExternal : randomInternal)(random)
 
 const functionalShuffle = (deck, state) => {
   let randState = typeof state !== 'object' ? newRandGen(state) : state
@@ -52,10 +52,10 @@ const functionalShuffle = (deck, state) => {
 const fastShuffle = (randomSeed, deck) => {
   // if the first param is an object, assume it's a randomizer's state from a previous run
   if (typeof randomSeed === 'object') {
-    const [fnDeck, fnState] = randomSeed
+    const [fnDeck, fnState = randomInt()] = randomSeed
     return functionalShuffle(fnDeck, fnState)
   }
-  const random = makeRandom(randomSeed)
+  const random = randomSwitch(randomSeed)
   const shuffler = fisherYatesShuffle(random)
   // if no second param given, return a curried shuffler
   if (deck === undefined) return shuffler

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
-import MersenneTwister from 'mersenne-twister'
+import { randNext, newRandGen } from 'fn-mt'
 
 const randomFunction = (random) => {
   if (typeof random === 'function') {
     return random
   }
-  const Randomizer = new MersenneTwister(random)
-  return () => Randomizer.random()
+  let randState = newRandGen(random)
+  return () => {
+    const [nextInt, nextState] = randNext(randState)
+    randState = nextState
+    return nextInt / 2 ** 32
+  }
 }
 
 const ruffle = (randomSeed, deck) => {


### PR DESCRIPTION
* Swaps out `mersenne-twister` for `fn-mt`, which lets us have the state of the twister back
* Nicer syntax for passing in an array with state and getting an array with state back out, which makes it look nicer when used in Redux