### PR TITLE
only store the next int in state

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,38 @@ const shuffledDeck = shuffle(sortedDeck)
 // [ '3♥', '3♦', 'K♥', '6♦', 'J♣', '5♠', 'A♠', ...
 ```
 
-The named shuffle export, above, uses `Math.random` for entropy. If you import it without the brackets, you'll get a functionally pure shuffler, which you can give it an integer
+The named `shuffle` export seen above uses `Math.random` for entropy. If you import it without the brackets, you'll get a deterministic shuffler which takes a number for its random seed (e.g. `Date.now()`).
 
 ```js
 import shuffle from 'fast-shuffle'
 
 const letters = ['a', 'b', 'c', 'd', 'e']
-let pseudoShuffle = shuffle(12345)
+const shuffleRed = shuffle(12345)
+shuffleRed(letters) // [ 'a', 'b', 'c', 'd', 'e' ]
+shuffleRed(letters) // [ 'a', 'd', 'b', 'e', 'c' ]
+shuffleRed(letters) // [ 'c', 'a', 'e', 'b', 'd' ]
+shuffleRed(letters) // [ 'b', 'c', 'e', 'a', 'd' ]
 
-pseudoShuffle(letters) // [ 'e', 'd', 'a', 'c', 'b' ]
-pseudoShuffle(letters) // [ 'a', 'e', 'c', 'b', 'd' ]
-
-pseudoShuffle = shuffle(12345)
-pseudoShuffle(letters) // [ 'e', 'd', 'a', 'c', 'b' ]
-pseudoShuffle(letters) // [ 'a', 'e', 'c', 'b', 'd' ]
+const shuffleBlue = shuffle(12345)
+shuffleBlue(letters) // [ 'a', 'b', 'c', 'd', 'e' ]
+shuffleBlue(letters) // [ 'a', 'd', 'b', 'e', 'c' ]
+shuffleBlue(letters) // [ 'c', 'a', 'e', 'b', 'd' ]
+shuffleBlue(letters) // [ 'b', 'c', 'e', 'a', 'd' ]
 ```
 
-It doesn't mutate the original array, instead it gives you back a shallow copy, which is important for Redux/React and [performance reasons](https://redux.js.org/faq/performance).
+The parameters are also curried, so it can be used in [pipelines](https://github.com/tc39/proposal-pipeline-operator).
+
+```js
+import shuffle from 'fast-shuffle'
+
+const randomCapitalLetter =
+  ['a', 'b', 'c', 'd', 'e', 'f']   // :: () -> [a]
+  |> shuffle(Math.random),         // :: [a] -> [a]
+  |> _ => _[0]                     // :: [a] -> a
+  |> _ => _.toUpperCase()          // :: a -> a
+```
+
+If you give it an array of your array and a random seed, you'll get a shuffled array and a new random seed back. This is a pure function, so you can use it in your Redux reducers.
 
 ```js
 import { SHUFFLE_DECK } from './actions'
@@ -70,17 +85,7 @@ const dealerApp = (state = initialState, action) => {
 }
 ```
 
-The parameters are also curried, so it can be used in [pipelines](https://github.com/tc39/proposal-pipeline-operator).
-
-```js
-import shuffle from 'fast-shuffle'
-
-const randomCapitalLetter =
-  ['a', 'b', 'c', 'd', 'e', 'f']   // :: () -> [a]
-  |> shuffle(Math.random),     // :: [a] -> [a]
-  |> _ => _[0]                     // :: [a] -> a
-  |> _ => _.toUpperCase()          // :: a -> a
-```
+Shuffle doesn't mutate the original array, instead it gives you back a shallow copy. This is important for React and [performance reasons](https://redux.js.org/faq/performance).
 
 ## Why not use existing libraries?
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,5 +1,4 @@
 import { pipe } from 'ramda'
-import { newRandGen } from 'fn-mt'
 import fastShuffle, { shuffle } from '..'
 
 describe('default', () => {
@@ -123,7 +122,7 @@ describe('fastShuffle for reducers', () => {
     expect.assertions(2)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const [d2, seedState] = fastShuffle([d1, 12345])
-    expect(seedState).toBeInstanceOf(Object)
+    expect(seedState).not.toBeUndefined()
     expect(d2).toStrictEqual(['B', 'H', 'F', 'C', 'G', 'A', 'D', 'E'])
   })
 
@@ -134,17 +133,6 @@ describe('fastShuffle for reducers', () => {
     const [d2] = fastShuffle([s1, 67890])
     expect(d1).not.toStrictEqual(d2)
     expect(d1.sort()).toStrictEqual(d2.sort())
-  })
-
-  it('accepts [array, object]', () => {
-    expect.assertions(4)
-    const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
-    const oldState = newRandGen(12345)
-    const [d2, newState] = fastShuffle([d1, oldState])
-    expect(oldState).toBeInstanceOf(Object)
-    expect(newState).toBeInstanceOf(Object)
-    expect(oldState).not.toStrictEqual(newState)
-    expect(d2).toStrictEqual(['B', 'H', 'F', 'C', 'G', 'A', 'D', 'E'])
   })
 
   it('finds its own seed, if not given one', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
-import { newRandGen, randRange } from 'fn-mt'
+import { newRandGen, randNext, randRange } from 'fn-mt'
 
 /**
  * This is the algorithm. Random should be a function that when given
- * an integer, returns an integer 0..n; basically "give me a random index for
- * my array. I have a hunch most of the time we will just get a seed, and should
- * generate our own random function. Unfortunately Javascript does not let us
- * seed the Math.random randomizer, so this uses fn-mt.
+ * an integer, returns an integer 0..n. I have a hunch most of the time
+ * we will just get a seed, but if you're reading this please tell me
+ * if you ever send in your own randomizer :)
  */
 const fisherYatesShuffle = (random) => (sourceArray) => {
   const clone = sourceArray.slice(0)
@@ -40,17 +39,16 @@ const randomSwitch = (random) =>
   (typeof random === 'function' ? randomExternal : randomInternal)(random)
 
 const functionalShuffle = (deck, state) => {
-  let randState = typeof state !== 'object' ? newRandGen(state) : state
+  let randState = newRandGen(state)
   const random = (maxIndex) => {
     const [nextInt, nextState] = randRange(0, maxIndex, randState)
     randState = nextState
     return nextInt
   }
-  return [fisherYatesShuffle(random)(deck), randState]
+  return [fisherYatesShuffle(random)(deck), randNext(randState)[0]]
 }
 
 const fastShuffle = (randomSeed, deck) => {
-  // if the first param is an object, assume it's a randomizer's state from a previous run
   if (typeof randomSeed === 'object') {
     const [fnDeck, fnState = randomInt()] = randomSeed
     return functionalShuffle(fnDeck, fnState)


### PR DESCRIPTION
It's ugly throwing the whole mersenne twister state into the Redux state. I think just storing the next random would be sufficient. Inside the tight shuffle loop, it's always calling nextRand with a full state which is important. It does mean generating a new twister at the beginning of every shuffle, though.