### PR TITLE
Fix default shuffler

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ const dealerApp = (state = initialState, action) => {
       const [ deck, randomizer ] = shuffle([state.deck, state.randomizer])
       return {
         ...state,
+        deck,
         randomizer,
-        deck
       }
     ...
     default:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const randomCapitalLetter =
   |> _ => _.toUpperCase()          // :: a -> a
 ```
 
-The named `shuffle` export seen above uses `Math.random` for entropy. If you import it without the brackets, you'll get a deterministic shuffler which takes a number for its random seed (e.g. `Date.now()`).
+The named `shuffle` export seen above uses `Math.random` for entropy. If you import it without the brackets, you'll get a deterministic shuffler which takes an int for its random seed (e.g. `Date.now()`).
 
 ```js
 import shuffle from 'fast-shuffle' // note the change

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ import shuffle from 'fast-shuffle'
 
 const initialState = {
   ...
-  randomizer: Date.now(),
-  deck: ['♣', '♦', '♥', '♠']
+  deck: ['♣', '♦', '♥', '♠'],
+  randomizer: Date.now()
 }
 
 const dealerApp = (state = initialState, action) => {

--- a/README.md
+++ b/README.md
@@ -25,10 +25,24 @@ const shuffledDeck = shuffle(sortedDeck)
 // [ '3♥', '3♦', 'K♥', '6♦', 'J♣', '5♠', 'A♠', ...
 ```
 
+The parameters are also curried, so it can be used in [pipelines](https://github.com/tc39/proposal-pipeline-operator).
+
+```js
+import { shuffle } from 'fast-shuffle'
+
+
+
+const randomCapitalLetter =
+  ['a', 'b', 'c', 'd', 'e', 'f']   // :: () -> [a]
+  |> shuffle,                      // :: [a] -> [a]
+  |> _ => _[0]                     // :: [a] -> a
+  |> _ => _.toUpperCase()          // :: a -> a
+```
+
 The named `shuffle` export seen above uses `Math.random` for entropy. If you import it without the brackets, you'll get a deterministic shuffler which takes a number for its random seed (e.g. `Date.now()`).
 
 ```js
-import shuffle from 'fast-shuffle'
+import shuffle from 'fast-shuffle' // note the change
 
 const letters = ['a', 'b', 'c', 'd', 'e']
 const shuffleRed = shuffle(12345)
@@ -42,18 +56,6 @@ shuffleBlue(letters) // [ 'a', 'b', 'c', 'd', 'e' ]
 shuffleBlue(letters) // [ 'a', 'd', 'b', 'e', 'c' ]
 shuffleBlue(letters) // [ 'c', 'a', 'e', 'b', 'd' ]
 shuffleBlue(letters) // [ 'b', 'c', 'e', 'a', 'd' ]
-```
-
-The parameters are also curried, so it can be used in [pipelines](https://github.com/tc39/proposal-pipeline-operator).
-
-```js
-import shuffle from 'fast-shuffle'
-
-const randomCapitalLetter =
-  ['a', 'b', 'c', 'd', 'e', 'f']   // :: () -> [a]
-  |> shuffle(Math.random),         // :: [a] -> [a]
-  |> _ => _[0]                     // :: [a] -> a
-  |> _ => _.toUpperCase()          // :: a -> a
 ```
 
 If you give it an array of your array and a random seed, you'll get a shuffled array and a new random seed back. This is a pure function, so you can use it in your Redux reducers.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,4 @@
 {
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "name": "fast-shuffle",
   "version": "4.2.0",
   "description": "A fast implementation of a fisher-yates shuffle that does not mutate the source array.",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "name": "fast-shuffle",
   "version": "4.2.0",
   "description": "A fast implementation of a fisher-yates shuffle that does not mutate the source array.",

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,6 @@ const fastShuffle = (randomSeed, deck) => {
   return shuffler(deck)
 }
 
-export const shuffle = fastShuffle(Math.random)
+export const shuffle = fastShuffle(randomInt())
 
 export default fastShuffle


### PR DESCRIPTION
Default shuffler was always shuffling with the same seed, because Math.random was giving it a float, rather than an int. This fixes that by having it use our randomInt function