### PR TITLE
Had a problem with the typings in 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "fn-mt": "1.2.1"
+    "fn-mt": "^1.2.1"
   },
   "devDependencies": {
     "@philihp/eslint-config": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "fn-mt": "^1.2.1"
+    "fn-mt": "1.2.1"
   },
   "devDependencies": {
     "@philihp/eslint-config": "6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { newRandGen, randNext, randRange } from 'fn-mt'
 
+type FastShuffleState = [deck: any[], seed: number];
+
 /**
  * This is the algorithm. Random should be a function that when given
  * an integer, returns an integer 0..n. I have a hunch most of the time
@@ -40,18 +42,20 @@ const randomSwitch = (random: (number | (() => number))) =>
     randomExternal(random) :
     randomInternal(random)
 
-
-const functionalShuffle = (deck: any[], state: number) => {
+const functionalShuffle = (deck: any[], state: number): FastShuffleState => {
   let randState = newRandGen(state)
   const random = (maxIndex: number) => {
     const [nextInt, nextState] = randRange(0, maxIndex, randState)
     randState = nextState
     return nextInt
   }
-  return [fisherYatesShuffle(random)(deck), randNext(randState)[0]]
+  return [fisherYatesShuffle(random)(deck), randNext(randState)[0]];
 }
 
-const fastShuffle = (randomSeed: (number | [any[], number]), deck?: any[]) => {
+function fastShuffle(seed: number): ((deck: any[]) => (typeof deck[number])[])
+function fastShuffle(seed: number, deck: any[]): (typeof deck[number])[]
+function fastShuffle(fnParams: FastShuffleState): FastShuffleState
+function fastShuffle(randomSeed: number | FastShuffleState, deck?: any[]) {
   if (typeof randomSeed === 'object') {
     const fnDeck = randomSeed[0]
     const fnState = randomSeed[1] || randomInt()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { newRandGen, randNext, randRange } from 'fn-mt'
 
-type FastShuffleState = [deck: any[], seed: number];
+type FastShuffleState<T> = [deck: T[], seed: number];
 
 /**
  * This is the algorithm. Random should be a function that when given
@@ -42,7 +42,7 @@ const randomSwitch = (random: (number | (() => number))) =>
     randomExternal(random) :
     randomInternal(random)
 
-const functionalShuffle = (deck: any[], state: number): FastShuffleState => {
+const functionalShuffle = <T>(deck: T[], state: number): FastShuffleState<T> => {
   let randState = newRandGen(state)
   const random = (maxIndex: number) => {
     const [nextInt, nextState] = randRange(0, maxIndex, randState)
@@ -52,22 +52,22 @@ const functionalShuffle = (deck: any[], state: number): FastShuffleState => {
   return [fisherYatesShuffle(random)(deck), randNext(randState)[0]];
 }
 
-function fastShuffle(seed: number): ((deck: any[]) => (typeof deck[number])[])
-function fastShuffle(seed: number, deck: any[]): (typeof deck[number])[]
-function fastShuffle(fnParams: FastShuffleState): FastShuffleState
-function fastShuffle(randomSeed: number | FastShuffleState, deck?: any[]) {
+function fastShuffle(randomSeed: number | (() => number)): <T>(deck: T[]) => T[]
+function fastShuffle<T>(randomSeed: number | (() => number), deck: T[]): T[]
+function fastShuffle<T>(fnParams: [deck: T[], randomSeed?: number]): FastShuffleState<T>
+function fastShuffle(randomSeed: number | (() => number) | [deck: unknown[], randomSeed?: number], deck?: unknown[]) {
   if (typeof randomSeed === 'object') {
-    const fnDeck = randomSeed[0]
-    const fnState = randomSeed[1] || randomInt()
-    return functionalShuffle(fnDeck, fnState)
+    const fnDeck = randomSeed[0];
+    const fnState = randomSeed[1] ?? randomInt();
+    return functionalShuffle(fnDeck, fnState);
   }
-  const random = randomSwitch(randomSeed)
-  const shuffler = fisherYatesShuffle(random)
+  const random = randomSwitch(randomSeed);
+  const shuffler = fisherYatesShuffle(random);
   // if no second param given, return a curried shuffler
-  if (deck === undefined) return shuffler
-  return shuffler(deck)
+  if (deck === undefined) return shuffler;
+  return shuffler(deck);
 }
 
-export const shuffle = (deck: any[]) => fastShuffle(randomInt(), deck)
+export const shuffle = <T>(deck: T[]) => fastShuffle(randomInt(), deck)
 
 export default fastShuffle


### PR DESCRIPTION
I had an issue with typings in 5.0.1.  Specifically the type definition of **shuffle** was `shuffle(deck: any[]): any[] | ((sourceArray: any[]) => any[])`, instead of just `shuffle(deck: any[]): any[]`.  

I could've just cast that function, but I wanted to do things "correctly" and I tried to make the overloads of **fastShuffle** work properly.  I ran into a problem that I couldn't figure the right declaration for the function expression version of fastShuffle, so I made it into a function.  I don't know if this functionally creates a difference.

Additional changes:
* Made the overloads accept a generic parameter for the array types.
* Added RNG as a possible parameter for randomSeed since it seems you're testing for that already and it appears to be supported.
* Changes the assignment to **fnState** to use null coalescing operator.  Did this since conceivably 0 could be passed as a seed;

Cheers.  Thanks for the package!