### PR TITLE
build: update to eslint 9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,22 @@
+// @ts-check
+
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['**/dist/**', 'eslint.config.mjs']
+  },
+  {
+    files: ['src/**/*.ts'],
+    extends: [eslint.configs.recommended,
+      ...tseslint.configs.recommended
+    ],
+    rules: {
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+    }
+  }
+)

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "lint": "eslint --ext .js,.ts src",
-    "prepare": "npm run build",
+    "lint": "eslint src",
+    "prepare": "husky",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
@@ -38,23 +38,21 @@
     "pcg": "1.1.0"
   },
   "devDependencies": {
-    "@philihp/eslint-config": "6.1.0",
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/node20": "20.1.4",
     "@types/jest": "29.5.13",
     "@types/ramda": "0.30.2",
-    "@typescript-eslint/eslint-plugin": "8.6.0",
-    "@typescript-eslint/parser": "8.6.0",
-    "eslint": "8.57.1",
-    "eslint-import-resolver-typescript": "3.6.3",
-    "eslint-plugin-import": "2.30.0",
+    "eslint": "9.11.1",
+    "eslint-plugin-jest": "28.8.3",
+    "eslint-plugin-prettier": "5.2.1",
     "husky": "9.1.6",
     "jest": "29.7.0",
     "lint-staged": "15.2.10",
     "prettier": "3.3.3",
     "ramda": "0.30.1",
     "ts-jest": "29.2.5",
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "typescript-eslint": "8.0.0-alpha.10"
   },
   "jest": {
     "preset": "ts-jest",
@@ -65,59 +63,9 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,.ts,.tsx}": [
-      "eslint --ext .js,.ts --fix"
+      "eslint src --fix",
+      "prettier --write"
     ]
   },
-  "prettier": "@philihp/prettier-config",
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "eslintConfig": {
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.json"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "@philihp",
-      "plugin:jest/all",
-      "plugin:@typescript-eslint/recommended"
-    ],
-    "settings": {
-      "import/extensions": [
-        ".js",
-        ".ts"
-      ],
-      "import/parsers": {
-        "@typescript-eslint/parser": [
-          ".ts"
-        ]
-      },
-      "import/resolver": {
-        "typescript": {},
-        "node": {
-          "extensions": [
-            ".js",
-            ".ts"
-          ]
-        }
-      }
-    },
-    "rules": {
-      "@typescript-eslint/ban-ts-comment": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "import/no-extraneous-dependencies": [
-        "error",
-        {
-          "devDependencies": [
-            "**/*.test.ts"
-          ]
-        }
-      ]
-    }
-  }
+  "prettier": "@philihp/prettier-config"
 }


### PR DESCRIPTION
* updates to eslint 9
* uses the alpha build of typescript-eslint per https://github.com/typescript-eslint/typescript-eslint/issues/8211
* uses new eslint flat config, pulling it out of package.json. better to be in the habit of this, since CI usually caches dependencies on a hash of package.json
* updates configuration of husky