### PR TITLE
chore: modernize toolchain and drop ramda

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -11,13 +11,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 16.x # deprecated
-          - 17.x # deprecated
-          - 18.x # EOL 2025-04-30
-          - 19.x # deprecated
           - 20.x # EOL 2026-04-30
-          - 21.x # deprecated
           - 22.x # EOL 2027-04-30
+          - 24.x # EOL 2028-04-30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -16,7 +16,17 @@
     "curried"
   ],
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "files": [
     "/dist",
     "!/dist/**/__tests__/*"
@@ -25,12 +35,14 @@
     "test": "test"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc -p tsconfig.build.esm.json",
+    "build:cjs": "tsc -p tsconfig.build.cjs.json && node -e \"require('node:fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "lint": "eslint src",
     "prepare": "husky",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "node --import tsx --test 'src/**/*.test.ts'",
+    "test:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\" && node --import tsx --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test 'src/**/*.test.ts'",
+    "test:watch": "node --import tsx --test --watch 'src/**/*.test.ts'"
   },
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",
@@ -38,28 +50,17 @@
     "pcg": "1.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "10.0.1",
     "@philihp/prettier-config": "1.0.0",
-    "@tsconfig/node20": "20.1.9",
-    "@types/jest": "29.5.14",
-    "@types/ramda": "0.31.1",
+    "@tsconfig/node22": "22.0.2",
     "eslint": "10.3.0",
-    "eslint-plugin-jest": "29.15.2",
     "eslint-plugin-prettier": "5.5.5",
     "husky": "9.1.7",
-    "jest": "29.7.0",
     "lint-staged": "17.0.4",
     "prettier": "3.8.3",
-    "ramda": "0.32.0",
-    "ts-jest": "29.4.9",
+    "tsx": "4.20.3",
     "typescript": "5.9.3",
     "typescript-eslint": "8.59.2"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node",
-    "modulePathIgnorePatterns": [
-      "dist/"
-    ]
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,.ts,.tsx}": [

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "build:cjs": "tsc -p tsconfig.build.cjs.json && node -e \"require('node:fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "lint": "eslint src",
     "prepare": "husky",
-    "test": "node --import tsx --test 'src/**/*.test.ts'",
-    "test:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\" && node --import tsx --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test 'src/**/*.test.ts'",
-    "test:watch": "node --import tsx --test --watch 'src/**/*.test.ts'"
+    "test": "node --import tsx --test src/__tests__/index.test.ts",
+    "test:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\" && node --import tsx --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test src/__tests__/index.test.ts",
+    "test:watch": "node --import tsx --test --watch src/__tests__/index.test.ts"
   },
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,26 +1,29 @@
-import { pipe } from 'ramda'
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
 import { shuffle, createShuffle } from '..'
+
+const pipe =
+  (...fns: Array<(...args: any[]) => any>) =>
+  (...args: any[]) =>
+    fns.reduce<any>((value, fn, i) => (i === 0 ? fn(...args) : fn(value)), undefined)
 
 describe('default', () => {
   it('shuffles the array', () => {
-    expect.assertions(2)
     const pseudoShuffle = createShuffle(12345)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const d2 = pseudoShuffle(d1)
-    expect(d2).toStrictEqual(expect.arrayContaining(d1))
-    expect(d2).toHaveLength(d1.length)
+    for (const item of d1) assert.ok(d2.includes(item))
+    assert.equal(d2.length, d1.length)
   })
 
   it('does not mutate the source', () => {
-    expect.assertions(1)
     const pseudoShuffle = createShuffle(12345)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     pseudoShuffle(d1)
-    expect(d1).toMatchObject(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'])
+    assert.deepEqual(d1, ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'])
   })
 
   it('does a shallow clone', () => {
-    expect.assertions(3)
     const pseudoShuffle = createShuffle(12345)
     const d1 = [
       { name: 'Alice', money: 10 },
@@ -28,39 +31,35 @@ describe('default', () => {
       { name: 'Cindy', money: 15 },
     ]
     const d2 = pseudoShuffle(d1)
-    expect(d2).toContain(d1[0])
-    expect(d2).toContain(d1[1])
-    expect(d2).toContain(d1[2])
+    assert.ok(d2.includes(d1[0]))
+    assert.ok(d2.includes(d1[1]))
+    assert.ok(d2.includes(d1[2]))
   })
 
   it('can be sorted back into the source array', () => {
-    expect.assertions(1)
     const pseudoShuffle = createShuffle(12345)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'].sort()
     const d2 = pseudoShuffle(d1)
     const d3 = d2.sort()
-    expect(d3).toMatchObject(d1)
+    assert.deepEqual(d3, d1)
   })
 
   it('scales calls to random linearly', () => {
-    expect.assertions(1)
     const d = new Array(10000)
-    const rng = jest.fn()
+    const rng = mock.fn()
     createShuffle(rng)(d)
-    expect(rng).toHaveBeenCalledTimes(d.length)
+    assert.equal(rng.mock.callCount(), d.length)
   })
 
   it('can be piped as a curried function', () => {
-    expect.assertions(1)
     const pseudoShuffle = createShuffle(12345)
     const letters = () => ['a', 'b', 'c', 'd']
     const head = (array: any[]) => array?.[0]
     const drawCard = pipe(letters, pseudoShuffle, head)
-    expect(drawCard()).toBe('c')
+    assert.equal(drawCard(), 'c')
   })
 
   it('accepts a custom random function', () => {
-    expect.assertions(1)
     const noise = [
       0.8901547130662948, 0.3163755603600294, 0.1307072939816823, 0.1839188123121576, 0.0397594964593742,
       0.2045602793853012, 0.8264361317269504, 0.5677250262815505, 0.5320779164321721, 0.5955447026062757,
@@ -69,11 +68,10 @@ describe('default', () => {
     const pseudoShuffle = createShuffle(() => noise.pop())
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const d2 = pseudoShuffle(d1)
-    expect(d1).not.toStrictEqual(d2)
+    assert.notDeepEqual(d1, d2)
   })
 
   it('accepts a custom random function that gives floats (0..1)', () => {
-    expect.assertions(2)
     const noise = [
       0.8901547130662948, 0.3163755603600294, 0.1307072939816823, 0.1839188123121576, 0.0397594964593742,
       0.2045602793853012, 0.8264361317269504, 0.5677250262815505, 0.5320779164321721, 0.5955447026062757,
@@ -82,59 +80,53 @@ describe('default', () => {
     const pseudoShuffle = createShuffle(() => noise.pop())
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const d2 = pseudoShuffle(d1)
-    expect(d1).not.toStrictEqual(d2)
-    expect(d1.sort()).toStrictEqual(d2.sort())
+    assert.notDeepEqual(d1, d2)
+    assert.deepEqual(d1.sort(), d2.sort())
   })
 
   it('also, rather than curried, accepts a seed and the source array', () => {
-    expect.assertions(1)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const d2 = createShuffle(12345, d1)
-    expect(d2).toStrictEqual(['C', 'G', 'H', 'B', 'F', 'D', 'E', 'A'])
+    assert.deepEqual(d2, ['C', 'G', 'H', 'B', 'F', 'D', 'E', 'A'])
   })
 })
 
 describe('shuffle', () => {
   it('works with massive noise', () => {
-    expect.assertions(1)
     // @ts-ignore
     const d1 = new Array(500).fill().map((_, i) => i)
     const d2 = shuffle(d1)
-    expect(d1.sort()).toMatchObject(d2.sort())
+    assert.deepEqual(d1.sort(), d2.sort())
   })
 })
 
 describe('createShuffle for reducers', () => {
   it('accepts [array, number]', () => {
-    expect.assertions(2)
     const d1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const [d2, seedState] = createShuffle([d1, 12345])
-    expect(seedState).toBeDefined()
-    expect(d2).toStrictEqual(['C', 'G', 'H', 'B', 'F', 'D', 'E', 'A'])
+    assert.notEqual(seedState, undefined)
+    assert.deepEqual(d2, ['C', 'G', 'H', 'B', 'F', 'D', 'E', 'A'])
   })
 
   it('returns different arrays with different seed ints', () => {
-    expect.assertions(2)
     const s1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const [d1] = createShuffle([s1, 12345])
     const [d2] = createShuffle([s1, 67890])
-    expect(d1).not.toStrictEqual(d2)
-    expect(d1.sort()).toStrictEqual(d2.sort())
+    assert.notDeepEqual(d1, d2)
+    assert.deepEqual(d1.sort(), d2.sort())
   })
 
   it('finds its own seed, if not given one', () => {
-    expect.assertions(1)
     const s1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const [d1] = createShuffle([s1, undefined])
-    expect(s1.every((r) => d1.includes(r))).toBe(true)
+    assert.ok(s1.every((r) => d1.includes(r)))
   })
 
   it('nondeterministically seeds, if no seed provided', () => {
-    expect.assertions(2)
     const s1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const [d1, r1] = createShuffle([s1, undefined])
     const [d2, r2] = createShuffle([s1, undefined])
-    expect(d1.every((r: any) => d2.includes(r))).toBe(true)
-    expect(r1).not.toStrictEqual(r2)
+    assert.ok(d1.every((r: any) => d2.includes(r)))
+    assert.notEqual(r1, r2)
   })
 })

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "verbatimModuleSyntax": false,
+    "outDir": "./dist/cjs"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "./dist/esm"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "src/**/*.test.ts"
-  ]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true


### PR DESCRIPTION
## Summary

- Drop `ramda` / `@types/ramda`. The only ramda usage was `pipe` in the test, replaced with a tiny local helper that preserves the same composition pattern.
- Replace `jest` + `ts-jest` with Node's built-in test runner (`node:test`, `node:assert/strict`, `mock.fn`) executed via `tsx`.
- Emit dual ESM + CJS builds:
  - `dist/esm/` from `tsconfig.build.esm.json` (module: nodenext)
  - `dist/cjs/` from `tsconfig.build.cjs.json` (module: commonjs), with a generated `dist/cjs/package.json` containing `{"type":"commonjs"}` so Node interprets the output correctly under the root `"type": "module"`.
  - `package.json` now declares `"type": "module"` and conditional `exports` for `import` / `require` / `types`.
- Bump `tsconfig` base from `@tsconfig/node20` to `@tsconfig/node22` to match `.node-version`.
- Trim CI test matrix to currently supported LTS versions (20, 22, 24); drop deprecated 16/17/18/19/21.
- Add `@eslint/js` as an explicit devDependency (was previously transitive).

## Test plan

- [x] `npm test` — 14/14 pass via `node:test`
- [x] `npm run test:coverage` — 100% line/branch/function coverage; `coverage/lcov.info` written for Coveralls
- [x] `npm run lint` — clean
- [x] `npm run build` — emits both `dist/esm/` and `dist/cjs/` with `.d.ts`
- [x] Smoke-test `require('fast-shuffle')` (CJS) and `import {createShuffle} from 'fast-shuffle'` (ESM) — both produce the same deterministic shuffle


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggi4cv1a6aG9qzP8WkTPmv)_