### PR TITLE
replace leftover jest expect() with node:assert

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -126,7 +126,7 @@ describe('createShuffle for reducers', () => {
     const s1 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     const [d1, r1] = createShuffle([s1, undefined])
     const [d2, r2] = createShuffle([s1, undefined])
-    expect(d1.every((r: string) => d2.includes(r))).toBe(true)
-    expect(r1).not.toStrictEqual(r2)
+    assert.ok(d1.every((r: string) => d2.includes(r)))
+    assert.notDeepEqual(r1, r2)
   })
 })


### PR DESCRIPTION
## Summary
- Replace two leftover Jest `expect()` calls in `src/__tests__/index.test.ts` with `node:assert/strict` equivalents.
- These were missed in the jest→`node:test` migration (#761) and caused the "nondeterministically seeds, if no seed provided" test to throw `ReferenceError: expect is not defined`.

## Test plan
- [x] `npm test` — all 14 tests pass on Node 22
- [ ] CI green on Node 20.x / 22.x / 24.x

---
_Generated by [Claude Code](https://claude.ai/code/session_017eQ9CyaGof1ohUxHCucFgG)_