### PR TITLE
update tsx and typescript to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "husky": "9.1.7",
     "lint-staged": "17.0.4",
     "prettier": "3.8.3",
-    "tsx": "4.20.3",
-    "typescript": "5.9.3",
+    "tsx": "4.21.0",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.59.3"
   },
   "lint-staged": {

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "bundler",
     "verbatimModuleSyntax": false,
     "outDir": "./dist/cjs"
   },

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
     "verbatimModuleSyntax": false,
     "outDir": "./dist/cjs"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true
   },


### PR DESCRIPTION
## Summary
Bumps the only two dependencies that have newer versions available:

- `tsx` 4.20.3 → 4.21.0 (minor)
- `typescript` 5.9.3 → 6.0.3 (major)

All other packages (`pcg`, `@eslint/js`, `@philihp/prettier-config`, `@tsconfig/node22`, `eslint`, `eslint-plugin-prettier`, `husky`, `lint-staged`, `prettier`, `typescript-eslint`) are already at their latest published version.

### TypeScript 6.0 adjustments
TS 6.0 introduces two breaking changes that needed config tweaks:

1. **TS5011** — `rootDir` must now be set explicitly when `include` is broader than the source tree. Added `"rootDir": "./src"` in `tsconfig.json`.
2. **TS5107** — `moduleResolution: "node"` (alias for `node10`) is deprecated and removed in TS 7.0. Pinned `tsconfig.build.cjs.json` to `"moduleResolution": "node10"` plus `"ignoreDeprecations": "6.0"` to keep the CJS build green until a follow-up migrates it to `node16`.

### Verification
- `npm run build` — both ESM and CJS outputs build cleanly
- `npm test` — all 14 tests pass
- Smoke-tested compiled `dist/` (CJS + ESM) on Node 14.21, 16.20, 18.20, 20.20, 22.22, and 24.15 — all pass, so the declared `engines.node: ">=14"` floor still holds.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — 14/14 pass
- [x] Smoke test on Node 14/16/18/20/22/24
- [ ] CI green on 20.x/22.x/24.x

---
_Generated by [Claude Code](https://claude.ai/code/session_017eQ9CyaGof1ohUxHCucFgG)_