### PR TITLE
perf(deps): bump pcg to 2.0.0 for ~1.4x faster shuffles

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "pcg": "1.1.0"
+    "pcg": "2.0.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
## What

Bumps `pcg` from `1.1.0` → `2.0.0`.

`pcg@2.0.0` drops its `long.js` and `ramda` dependencies (now zero runtime deps, native BigInt internals, no curry overhead) and is a drop-in API replacement — `createPcg32` and `randomInt` keep the same signatures and the RNG output sequence is unchanged. The existing determinism test asserting `createShuffle(12345, ['A'..'H']) === ['C','G','H','B','F','D','E','A']` still passes, so anyone with persisted seeds keeps getting the same shuffles.

## Why

For every Fisher–Yates step (one per array element) the old `pcg@1.1.0` did ~10 `Long.mul`/`Long.add` allocations, a Ramda curry call, and a `{...pcg, state: ...}` immutable spread — for arithmetic that fundamentally is one 64-bit multiply + one 64-bit add + a few shifts/xors. `pcg@2.0.0` rewrites all that.

## Benchmark

Node 24, shuffling N elements with a fresh seed per call:

| N       | 1.1.0    | 2.0.0    | Speedup |
|--------:|---------:|---------:|--------:|
| 10      | 10.5 µs  | 7.7 µs   | ~1.4×   |
| 100     | 87 µs    | 68 µs    | ~1.3×   |
| 1 000   | 907 µs   | 658 µs   | ~1.4×   |
| 10 000  | 9.2 ms   | 6.6 ms   | ~1.4×   |
| 100 000 | 102 ms   | 78 ms    | ~1.3×   |

## Test plan

- [x] `npm test` — all 14 tests pass, including the determinism assertion
- [x] `npm run test:coverage` — 100% line / branch / function coverage
- [x] `npm run build` — esm + cjs builds clean
