### PR TITLE
perf: skip final random call in fisherYatesShuffle

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -48,7 +48,7 @@ describe('default', () => {
     const d = new Array(10000)
     const rng = mock.fn()
     createShuffle(rng)(d)
-    assert.equal(rng.mock.callCount(), d.length)
+    assert.equal(rng.mock.callCount(), d.length - 1)
   })
 
   it('can be piped as a curried function', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,12 @@ const fisherYatesShuffle = (random: (arg: number) => number) => (sourceArray: un
   let destinationIndex = 0
   const shuffled = new Array(sourceIndex)
 
-  while (sourceIndex) {
+  while (sourceIndex > 1) {
     const randomIndex = random(sourceIndex)
     shuffled[destinationIndex++] = clone[randomIndex]
     clone[randomIndex] = clone[--sourceIndex]
   }
+  if (sourceIndex) shuffled[destinationIndex] = clone[0]
 
   return shuffled
 }


### PR DESCRIPTION
## Summary
- Skip the wasted final iteration of the Fisher-Yates loop, where `random(1)` always returns `0` and the swap is a no-op
- Copy the last remaining element directly into the result
- Update the `scales calls to random linearly` test to expect `length - 1` calls

Fixes #620

## Test plan
- [x] `npm test` — all 14 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01UdaVWU2CovtsthiKSSvyvr)_