### PR TITLE
fix(test): align reversal test with skip-final-call optimization

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -146,12 +146,11 @@ describe('reversal from full PCG state', () => {
     const shuffled = createShuffle(rng)(deck)
     assert.notDeepEqual(shuffled, deck)
 
-    const s4 = prevState(pcg)
-    const s3 = prevState(s4)
+    const s3 = prevState(pcg)
     const s2 = prevState(s3)
     const s1 = prevState(s2)
     const s0 = prevState(s1)
-    const replayed = [getOutput(s0), getOutput(s1), getOutput(s2), getOutput(s3), getOutput(s4)]
+    const replayed = [getOutput(s0), getOutput(s1), getOutput(s2), getOutput(s3)]
 
     let cursor = 0
     const perm = createShuffle(() => replayed[cursor++])([0, 1, 2, 3, 4])


### PR DESCRIPTION
## Summary

The `reversal from full PCG state` test added in c7fc0f8 was failing on every push, breaking the test workflow.

`fisherYatesShuffle` exits its loop while `sourceIndex > 1`, so an n-element shuffle consumes **n-1** RNG outputs (this was the perf change in d6d4b25). The test was rewinding the PCG **5** times for a 5-element deck and replaying **5** outputs — leaving the pcg one state too far behind, so the recovery permutation disagreed with the original draw sequence.

```
Expected: ['a', 'b', 'c', 'd', 'e']
Actual:   ['c', 'd', 'a', 'b', 'e']
```

Fix: rewind 4 states and replay 4 outputs, matching the 4 calls the shuffle actually made.

## Test plan

- [x] `npm test` — 17/17 pass (was 16/17)
- [x] `npm run build` succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uietpf7oc25YXP4xwj9Dve)_