### PR TITLE
chore(release): 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.2.0]
+## [6.2.0] — 2026-05-26
 
 ### Performance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-shuffle",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "A fast implementation of a fisher-yates shuffle that does not mutate the source array.",
   "homepage": "https://github.com/philihp/fast-shuffle",
   "repository": "https://github.com/philihp/fast-shuffle.git",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `6.1.1` → `6.2.0`
- Dates the `[6.2.0]` entry in `CHANGELOG.md` as `2026-05-26`

## Verification
- `npm test` — 17/17 pass
- `npm run build` — ESM + CJS outputs clean
- `npm pack --dry-run` — produces `fast-shuffle-6.2.0.tgz` (4.3 kB, 8 files: LICENSE, README, dist/{esm,cjs}/{index.js,index.d.ts}, dist/cjs/package.json, package.json)
- `npm run lint` — 4 pre-existing `no-explicit-any` errors in `src/__tests__/index.test.ts`, also present on `main`, not blocking (CI doesn't run lint)

## Post-merge publish steps (manual, maintainer-only)
1. `git checkout main && git pull`
2. `git tag v6.2.0 && git push origin v6.2.0`
3. `npm publish` (with 2FA)
4. Draft a GitHub release pointing at the `[6.2.0]` CHANGELOG entry

https://claude.ai/code/session_01TuhNXbdHUHcsFcyPAmKW4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuhNXbdHUHcsFcyPAmKW4R)_