### PR TITLE
chore: clean up lint errors in test file

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -4,11 +4,6 @@ import { randomBytes } from 'node:crypto'
 import { createPcg32, nextState, prevState, getOutput } from 'pcg'
 import { shuffle, createShuffle } from '../index.ts'
 
-const pipe =
-  (...fns: Array<(...args: any[]) => any>) =>
-  (...args: any[]) =>
-    fns.reduce<any>((value, fn, i) => (i === 0 ? fn(...args) : fn(value)), undefined)
-
 describe('default', () => {
   it('shuffles the array', () => {
     const pseudoShuffle = createShuffle(12345)
@@ -57,7 +52,7 @@ describe('default', () => {
     const pseudoShuffle = createShuffle(12345)
     const letters = () => ['a', 'b', 'c', 'd']
     const head = (array: unknown[]) => array?.[0]
-    const drawCard = pipe(letters, pseudoShuffle, head)
+    const drawCard = () => head(pseudoShuffle(letters()))
     assert.equal(drawCard(), 'c')
   })
 


### PR DESCRIPTION
## Summary
- Removes the `pipe` test helper in `src/__tests__/index.test.ts` and inlines its single call site
- Eliminates 4 `@typescript-eslint/no-explicit-any` lint errors that were the only failures from `npm run lint`

## Context
The `pipe` helper was used in exactly one test ("can be piped as a curried function"). Its parameters and return type had to be `any[]` because TS can't naturally express variadic pipe chaining without overloads or recursive types. Replacing the call with `head(pseudoShuffle(letters()))` preserves the test's intent (that the shuffle composes cleanly) without the typing problem.

## Verification
- `npm run lint` — clean (was 4 errors)
- `npm test` — 17/17 pass

## Test plan
- [ ] Confirm the inlined call still expresses the "shuffle in a composition" intent the original test was checking

https://claude.ai/code/session_01TuhNXbdHUHcsFcyPAmKW4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuhNXbdHUHcsFcyPAmKW4R)_