### PR TITLE
fix: republish to restore README on npm package page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.1] — 2026-07-06
+
+### Fixed
+
+- Republish to restore the README on the npm package page — npmjs.com only refreshes the displayed README on a new version publish, and it was showing "This package does not have a README" for 6.2.0 despite the registry metadata containing valid README content. Also listed `README.md` explicitly in `files` for good measure.
+
 ## [6.2.0] — 2026-05-26
 
 ### Performance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-shuffle",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "A fast implementation of a fisher-yates shuffle that does not mutate the source array.",
   "homepage": "https://github.com/philihp/fast-shuffle",
   "repository": "https://github.com/philihp/fast-shuffle.git",
@@ -29,7 +29,8 @@
   },
   "files": [
     "/dist",
-    "!/dist/**/__tests__/*"
+    "!/dist/**/__tests__/*",
+    "/README.md"
   ],
   "directories": {
     "test": "test"


### PR DESCRIPTION
## Summary

npmjs.com's package page for `fast-shuffle` was showing "This package does not have a README" for the currently published `6.2.0`, even though the registry API (`registry.npmjs.org/fast-shuffle`) returns a `readme` field that's byte-for-byte identical to this repo's `README.md`, and the published tarball / unpkg CDN both serve the file correctly.

Per npm's own docs, the README shown on the package page is only refreshed when a new version is published — it isn't kept live-synced with the stored registry data. So the fix here is to publish a new version to force npm to reindex it.

- Bump version to `6.2.1` to trigger a fresh publish/reindex.
- Explicitly list `/README.md` in `package.json`'s `files` array (npm bundles it regardless, but this removes any ambiguity).
- Add a corresponding `CHANGELOG.md` entry.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — all 17 tests pass
- [x] `npm run lint` — passes
- [x] `npm pack --dry-run` — confirms `README.md` is included in the tarball
- [ ] Maintainer runs `npm publish` for `6.2.1` and confirms the README reappears on npmjs.com


---
_Generated by [Claude Code](https://claude.ai/code/session_01GC2U8YdshXtgRvDjhVVYHx)_